### PR TITLE
Feat/base tag input

### DIFF
--- a/delegate/Dockerfile
+++ b/delegate/Dockerfile
@@ -1,4 +1,5 @@
-FROM harness/delegate-immutable:<+pipeline.stages.trigger.spec.serviceConfig.serviceDefinition.spec.artifacts.primary.spec.tag>
+ARG DELEGATE_TAG=22.09.76822
+FROM harness/delegate-immutable:$DELEGATE_TAG
 
 USER 0
 

--- a/delegate/Dockerfile
+++ b/delegate/Dockerfile
@@ -1,4 +1,4 @@
-FROM harness/delegate-immutable:22.10.77021
+FROM harness/delegate-immutable:<+pipeline.stages.trigger.spec.serviceConfig.serviceDefinition.spec.artifacts.primary.spec.tag>
 
 USER 0
 


### PR DESCRIPTION
put the delegate base version as a build argument to be able to pass it at build time within harness.

this will let me trigger on a new base version and set it here to be automatically used.

default to current-1 version at time of pr.